### PR TITLE
Undo xmldb_mod_morsle_install function name to xmldb_morsle_install.

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -31,7 +31,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-function xmldb_mod_morsle_install() {
+function xmldb_morsle_install() {
     global $CFG;
 
 }


### PR DESCRIPTION
This is the proper way to define the function.
