### PR TITLE
Fixing Moodle errors

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -50,6 +50,7 @@ class mod_morsle_mod_form extends moodleform_mod {
         //-------------------------------------------------------
         $mform->addElement('header', 'content', get_string('contentheader', 'morsle'));
         $mform->addElement('url', 'externalurl', get_string('externalurl', 'morsle'), array('size'=>'60'), array('usefilepicker'=>true));
+        $mform->setType('externalurl', PARAM_URL);
         $mform->addRule('externalurl', null, 'required', null, 'client');
         //-------------------------------------------------------
         $mform->addElement('header', 'optionssection', get_string('optionsheader', 'morsle'));

--- a/settings.php
+++ b/settings.php
@@ -46,7 +46,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('morsle/framesize',
         get_string('framesize', 'morsle'), get_string('configframesize', 'morsle'), 130, PARAM_INT));
     $settings->add(new admin_setting_configcheckbox('morsle/requiremodintro',
-        get_string('requiremodintro', 'admin'), get_string('configrequiremodintro', 'admin'), 1));
+        get_string('requiremodintro', 'admin'), get_string('requiremodintro_desc', 'admin'), 1));
     $settings->add(new admin_setting_configpasswordunmask('morsle/secretphrase', get_string('password'),
         get_string('configsecretphrase', 'morsle'), ''));
     $settings->add(new admin_setting_configcheckbox('morsle/rolesinparams',


### PR DESCRIPTION
- Set externalurl type.
- Used new string that is present in Moodle 2.9+
